### PR TITLE
Added complex retry mechanism to submission creation.

### DIFF
--- a/tasks/store-publish/apiWrapper.ts
+++ b/tasks/store-publish/apiWrapper.ts
@@ -272,7 +272,14 @@ export function withRetry<T>(
             }
         }
 
-        if (numRetries > 0 && !errPredicate)
+        if (numRetries <= 0)
+        {
+            /* Don't wrap err in an error because it's already an error
+            (.fail() is the equivalent of "catch" for promises) */
+            throw err;
+        }
+
+        if (errPredicate)
         {
             var shouldRetry = errPredicate(err);
 
@@ -289,9 +296,8 @@ export function withRetry<T>(
         }
         else
         {
-            /* Don't wrap err in an error because it's already an error
-            (.fail() is the equivalent of "catch" for promises) */
-            throw err;
+            // If there is no error predicate, assume that the caller wants to always retry.
+            return success;
         }
     });
 }

--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -290,27 +290,26 @@ function createSubmission(): Q.Promise<any>
     var generator = () => api.performAuthenticatedRequest<any>(currentToken, requestParams);
     var retryFunc = async function (err)
     {
-        if (!is400Error(err))
+        if (is400Error(err))
         {
-            if (is500Error(err))
-            {
-                // If the submission creation fails, we should check if a submission was,
-                // in fact, created, and delete it if so.
-                tl.debug('Trying to recover from submission creation failure');
-                var appRes = await getAppResource();
-                if (taskParams.force && appRes.pendingApplicationSubmission != undefined)
-                {
-                    await deleteSubmission(appRes.pendingApplicationSubmission.resourceLocation);
-                }
-            }
-
-            /* It was either a 500 which we mitigated above, or it wasn't, in which case it was a
-             * transport-level error, so we can retry in both cases. */
-            return true;
+            return false;
         }
 
-        // It was a 400 error, so a problem on our side. Don't retry.
-        return false;
+        // If a 500 error occurred, try to recover from it.
+        if (is500Error(err))
+        {
+            tl.debug('Trying to recover from submission creation failure');
+
+            // If this fails, an exception will be thrown, and the retry procedure will be aborted
+            var appRes = await getAppResource();
+            if (taskParams.force && appRes.pendingApplicationSubmission != undefined)
+            {
+                await deleteSubmission(appRes.pendingApplicationSubmission.resourceLocation);
+            }
+        }
+
+        // As long as it's not a 400 error, we can retry
+        return true;
     }
 
     return api.withRetry(5, generator, err => Q(retryFunc(err)));


### PR DESCRIPTION
To retry submission creation (and POST in general), we need to be able to verify the status of the application, and see if a submission was actually created. If it was, we delete it and try again, because we don't know what state it's in (but it's probably bad if we hit an error).

This required to change the withRetry function to allow the error predicate to promise a boolean, since the recovery phase has to do some additional web requests.

Note that I'm **deliberately not** adding retries for commits. Those are trickier to deal with. A first strategy is: 
- Check the submission status
- If it's CommitStarted, then we can move on to the next step
- Otherwise retry as normal

The problem is that we really can't be sure of the state of the submission if that request failed. In the case of the creation, it's fine because we can just delete anything that popped up and try again. But for a commit, even if it "started", what was the error for? We don't know, and it might fail later on because of some corrupted state. At the same time, we can't do just a simple retry because that might fail if we are indeed in this weird half-state where the commit started but an error was thrown.

Therefore in any case, if we failed at commit time, we really don't know what's going on. It might be possible to recover from it, but the additional complexity in the task is not worth it.
