### PR TITLE
Increase timeout interval from 10s to 90s

### DIFF
--- a/tasks/common/apiHelper.ts
+++ b/tasks/common/apiHelper.ts
@@ -315,7 +315,7 @@ function uploadZip(filePath: string, blobUrl: string): Q.Promise<any>
     var blobService = azure.createBlobServiceWithSas(host, sasToken).withFilter(retryOperations);
     var options = {
         parallelOperationThreadCount: 5,
-        timeoutIntervalInMs: 10000,
+        timeoutIntervalInMs: 90000,
         maximumExecutionTimeInMs: 900000
     };
     var defer = Q.defer();


### PR DESCRIPTION
Increase the timeout interval from 10 seconds to 90 seconds so that blob upload won't timeout on slower connections.