### PR TITLE
Allow to skip waiting for release after submit packages (with backwards compatibility).

### DIFF
--- a/tasks/store-flight/flight.ts
+++ b/tasks/store-flight/flight.ts
@@ -34,6 +34,12 @@ export interface CoreFlightParams
 
     /** A path where the zip file to be uploaded to the dev center will be stored. */
     zipFilePath: string;
+
+    /** 
+     * If true, waiting to finish the submisons.
+     * Otherwise, not.
+     */
+    waiting: boolean;
 }
 
 export interface AppIdParam
@@ -120,9 +126,12 @@ export async function flightTask(params: FlightParams)
     console.log('Committing flight submission...');
     await commitFlightSubmission(flightSubmissionResource.id);
 
-    console.log('Polling flight submission...');
-    var resourceLocation = `applications/${appId}/flights/${flightId}/submissions/${flightSubmissionResource.id}`;
-    await api.pollSubmissionStatus(currentToken, resourceLocation, flightSubmissionResource.targetPublishMode);
+    if (taskParams.waiting)
+    {
+        console.log('Polling flight submission...');
+        var resourceLocation = `applications/${appId}/flights/${flightId}/submissions/${flightSubmissionResource.id}`;
+        await api.pollSubmissionStatus(currentToken, resourceLocation, flightSubmissionResource.targetPublishMode);
+    }
 
     tl.setResult(tl.TaskResult.Succeeded, 'Flight submission completed');
 }

--- a/tasks/store-flight/flightUi.ts
+++ b/tasks/store-flight/flightUi.ts
@@ -41,7 +41,7 @@ function gatherParams()
         force: tl.getBoolInput('force', true),
         zipFilePath: path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
         packages: [],
-        waiting: tl.getBoolInput('waiting', false)
+        waiting: tl.getBoolInput('waiting', true)
     };
 
     // Packages

--- a/tasks/store-flight/flightUi.ts
+++ b/tasks/store-flight/flightUi.ts
@@ -33,13 +33,15 @@ function gatherParams()
     }
 
     var taskParams: fli.FlightParams = {
+        appId: '',        
         appName: '',
         flightName: tl.getInput('flightName', true),
         authentication: credentials,
         endpoint: endpointUrl,
         force: tl.getBoolInput('force', true),
         zipFilePath: path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
-        packages: []
+        packages: [],
+        waiting: tl.getBoolInput('waiting', false)
     };
 
     // Packages
@@ -96,6 +98,7 @@ function dumpParams(taskParams: fli.FlightParams): void
     tl.debug(`Force delete: ${taskParams.force}`);
     tl.debug(`Packages: ${taskParams.packages.join(',')}`);
     tl.debug(`Local ZIP file path: ${taskParams.zipFilePath}`);
+    tl.debug(`Waiting: ${taskParams.waiting}`);
 }
 
 async function main()

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -87,6 +87,13 @@
             "label": "Additional package(s)",
             "required": false,
             "helpMarkDown": "Paths to any additional packages required by this application (one path per line). Minimatch pattern is supported."
+        },
+        {
+            "name": "waiting",
+            "type": "boolean",
+            "label": "Waiting to finish",
+            "defaultValue": false,
+            "required": true
         }
     ],
     "execution": {

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -91,9 +91,10 @@
         {
             "name": "waiting",
             "type": "boolean",
-            "label": "Waiting to finish",
-            "defaultValue": false,
-            "required": true
+            "label": "Waiting to Release",
+            "defaultValue": true,
+            "required": true,
+            "helpMarkDown": "It may take several hours."
         }
     ],
     "execution": {

--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -67,6 +67,12 @@ export interface CorePublishParams
 
     /** A path where the zip file to be uploaded to the dev center will be stored. */
     zipFilePath: string;
+
+    /** 
+     * If true, waiting to finish the submisons.
+     * Otherwise, not.
+     */
+    waiting: boolean;
 }
 
 export interface AppIdParam
@@ -158,9 +164,12 @@ export async function publishTask(params: PublishParams)
     console.log('Committing submission...');
     await commitAppSubmission(submissionResource.id);
 
-    console.log('Polling submission...');
-    var resourceLocation = `applications/${appId}/submissions/${submissionResource.id}`;
-    await api.pollSubmissionStatus(currentToken, resourceLocation, submissionResource.targetPublishMode);
+    if (taskParams.waiting)
+    {
+        console.log('Polling submission...');
+        var resourceLocation = `applications/${appId}/submissions/${submissionResource.id}`;
+        await api.pollSubmissionStatus(currentToken, resourceLocation, submissionResource.targetPublishMode);
+    }
 
     tl.setResult(tl.TaskResult.Succeeded, 'Submission completed');
 }

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -42,7 +42,7 @@ function gatherParams()
         updateImages: tl.getBoolInput('updateImages', false),
         zipFilePath : path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
         packages : [],
-        waiting: tl.getBoolInput('waiting', false)
+        waiting: tl.getBoolInput('waiting', true)
     };
 
     // Packages

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -33,6 +33,7 @@ function gatherParams()
     }
 
     var taskParams: pub.PublishParams = {
+        appId : '',
         appName : '',
         authentication : credentials,
         endpoint : endpointUrl,
@@ -40,7 +41,8 @@ function gatherParams()
         metadataUpdateType: pub.MetadataUpdateType[<string>tl.getInput('metadataUpdateMethod', true)],
         updateImages: tl.getBoolInput('updateImages', false),
         zipFilePath : path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
-        packages : []
+        packages : [],
+        waiting: tl.getBoolInput('waiting', false)
     };
 
     // Packages
@@ -96,6 +98,7 @@ function dumpParams(taskParams: pub.PublishParams): void
     tl.debug(`Update images: ${taskParams.updateImages}`);
     tl.debug(`Metadata root: ${taskParams.metadataRoot}`);
     tl.debug(`Packages: ${taskParams.packages.join(',')}`);
+    tl.debug(`Waiting: ${taskParams.waiting}`);
 }
 
 async function main()

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -108,6 +108,13 @@
             "label": "Additional package(s)",
             "required": false,
             "helpMarkDown": "Paths to any additional packages required by this application (one path per line). Minimatch pattern is supported."
+        },
+        {
+            "name": "waiting",
+            "type": "boolean",
+            "label": "Waiting to finish",
+            "defaultValue": false,
+            "required": true
         }
     ],
     "execution": {

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -112,9 +112,10 @@
         {
             "name": "waiting",
             "type": "boolean",
-            "label": "Waiting to finish",
-            "defaultValue": false,
-            "required": true
+            "label": "Waiting to Release",
+            "defaultValue": true,
+            "required": true,
+            "helpMarkDown": "It may take several days."
         }
     ],
     "execution": {


### PR DESCRIPTION
To both tasks added new parameter "waiting"
`
        {
            "name": "waiting",
            "type": "boolean",
            "label": "Waiting to Release",
            "defaultValue": true,
            "required": true,
            "helpMarkDown": "It may take several hours."
        }
`
It have default value "true", so by default it is backwards compatibility. But user can uncheck this option to skip waiting release.