### PR TITLE
Allow to delete old packages from submission.

### DIFF
--- a/tasks/store-flight/flight.ts
+++ b/tasks/store-flight/flight.ts
@@ -29,6 +29,9 @@ export interface CoreFlightParams
      */
     force: boolean;
 
+    /** If true, delete any current packages from submission. Otherwise, leave current packages and add new packages. */
+    deleteCurrentPackages: boolean;
+
     /** A list of paths to the packages to be uploaded. */
     packages: string[];
 
@@ -177,6 +180,13 @@ function createFlightSubmission(): Q.Promise<any>
  */
 function putFlightSubmission(flightSubmissionResource: any): Q.Promise<void>
 {
+    if (taskParams.deleteCurrentPackages)
+    {
+        flightSubmissionResource.flightPackages.forEach(package => 
+        {
+            package.fileStatus = 'PendingDelete';
+        });
+    }
     api.includePackagesInSubmission(taskParams.packages, flightSubmissionResource.flightPackages);
 
     var url = `${api.ROOT}applications/${appId}/flights/${flightId}/submissions/${flightSubmissionResource.id}`;

--- a/tasks/store-flight/flight.ts
+++ b/tasks/store-flight/flight.ts
@@ -182,9 +182,9 @@ function putFlightSubmission(flightSubmissionResource: any): Q.Promise<void>
 {
     if (taskParams.deleteCurrentPackages)
     {
-        flightSubmissionResource.flightPackages.forEach(package => 
+        flightSubmissionResource.flightPackages.forEach(item => 
         {
-            package.fileStatus = 'PendingDelete';
+            item.fileStatus = 'PendingDelete';
         });
     }
     api.includePackagesInSubmission(taskParams.packages, flightSubmissionResource.flightPackages);

--- a/tasks/store-flight/flightUi.ts
+++ b/tasks/store-flight/flightUi.ts
@@ -38,6 +38,7 @@ function gatherParams()
         authentication: credentials,
         endpoint: endpointUrl,
         force: tl.getBoolInput('force', true),
+        deleteCurrentPackages: tl.getBoolInput('deleteCurrentPackages', true),
         zipFilePath: path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
         packages: []
     };

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -74,6 +74,14 @@
             "helpMarkDown": "Whether to delete an existing submission instead of failing the task"
         },
         {
+            "name": "deleteCurrentPackages",
+            "type": "boolean",
+            "label": "Delete current packages",
+            "defaultValue": false,
+            "required": true,
+            "helpMarkDown": "Delete current packages(*.appx,*.appxupload) from submission"
+        },
+        {
             "name": "packagePath",
             "type": "filePath",
             "label": "Package file",

--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -239,9 +239,9 @@ function putMetadata(submissionResource: any): Q.Promise<void>
 
     if (taskParams.deleteCurrentPackages)
     {
-        submissionResource.applicationPackages.forEach(package => 
+        submissionResource.applicationPackages.forEach(item => 
         {
-            package.fileStatus = 'PendingDelete';
+            item.fileStatus = 'PendingDelete';
         });
     }
 

--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -49,6 +49,9 @@ export interface CorePublishParams
      */
     force: boolean;
 
+    /** If true, delete any current packages from submission. Otherwise, leave current packages and add new packages. */
+    deleteCurrentPackages: boolean;
+
     metadataUpdateType: MetadataUpdateType;
 
     /**
@@ -232,6 +235,14 @@ function putMetadata(submissionResource: any): Q.Promise<void>
         taskParams.metadataRoot)
     {
         updateMetadata(submissionResource);
+    }
+
+    if (taskParams.deleteCurrentPackages)
+    {
+        submissionResource.applicationPackages.forEach(package => 
+        {
+            package.fileStatus = 'PendingDelete';
+        });
     }
 
     // Also at this point add the given packages to the list of packages to upload.

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -37,6 +37,7 @@ function gatherParams()
         authentication : credentials,
         endpoint : endpointUrl,
         force : tl.getBoolInput('force', true),
+        deleteCurrentPackages: tl.getBoolInput('deleteCurrentPackages', true),
         metadataUpdateType: pub.MetadataUpdateType[<string>tl.getInput('metadataUpdateMethod', true)],
         updateImages: tl.getBoolInput('updateImages', false),
         zipFilePath : path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -66,6 +66,14 @@
             "helpMarkDown": "Whether to delete an existing submission instead of failing the task"
         },
         {
+            "name": "deleteCurrentPackages",
+            "type": "boolean",
+            "label": "Delete current packages",
+            "defaultValue": false,
+            "required": true,
+            "helpMarkDown": "Delete current packages(*.appx,*.appxupload) from submission"
+        },
+        {
             "name": "metadataUpdateMethod",
             "type": "pickList",
             "label": "Metadata update method",


### PR DESCRIPTION
After publish flight several times we have package list like this:
1_app_10.0.39.0_x64.appxuploadd
2_app_10.0.39.0_x86.appxuploadd
0_app_10.0.39.0_ARM.appxupload
1_app_10.0.38.0_x64.appxuploadd
2_app_10.0.38.0_x86.appxuploadd
0_app_10.0.38.0_ARM.appxupload
1_app_10.0.37.0_x64.appxuploadd
2_app_10.0.37.0_x86.appxuploadd
0_app_10.0.37.0_ARM.appxupload
1_app_10.0.36.0_x64.appxuploadd
2_app_10.0.36.0_x86.appxuploadd
0_app_10.0.360_ARM.appxupload
...

So, this pull request added new options (disabled by default for backward compatibility) to remove old packages from submission.