### PR TITLE
#67 create but dont commit submission

### DIFF
--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -87,6 +87,9 @@ export interface CorePublishParams
     /** A path where the zip file to be uploaded to the dev center will be stored. */
     zipFilePath: string;
 
+    /** If false, we will only create the submission but not commit it. If false skipPolling will also be set to false. */
+    commitSubmission: boolean;
+
     /** If true, we will exit immediately after commit without polling submission till app is published. */
     skipPolling: boolean;
 
@@ -194,8 +197,16 @@ export async function publishTask(params: PublishParams)
         await api.persistZip(zip, taskParams.zipFilePath, submissionResource.fileUploadUrl);
     }
 
-    console.log('Committing submission...');
-    await commitAppSubmission(submissionResource.id);
+    if (taskParams.commitSubmission)
+    {
+        console.log('Committing submission...');
+        await commitAppSubmission(submissionResource.id);
+    }
+    else
+    {
+        taskParams.skipPolling = true;
+        console.log('Commit submission is false. Skipping commit and polling...');
+    }
 
     if (taskParams.skipPolling)
     {

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -43,6 +43,7 @@ function gatherParams()
         updateImages: tl.getBoolInput('updateImages', false),
         zipFilePath : path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
         packages : [],
+        commitSubmission : tl.getBoolInput('commitSubmission', true),
         skipPolling : tl.getBoolInput('skipPolling', true),
         numberOfPackagesToKeep: tl.getBoolInput('deletePackages') ? parseInt(tl.getInput('numberOfPackagesToKeep')) : null,
         mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null
@@ -101,6 +102,7 @@ function dumpParams(taskParams: pub.PublishParams): void
     tl.debug(`Update images: ${taskParams.updateImages}`);
     tl.debug(`Metadata root: ${taskParams.metadataRoot}`);
     tl.debug(`Packages: ${taskParams.packages.join(',')}`);
+    tl.debug(`commitSubmission: ${taskParams.commitSubmission}`);
     tl.debug(`skipPolling: ${taskParams.skipPolling}`);
     tl.debug(`deletePackages: ${taskParams.numberOfPackagesToKeep ? true : false}`);
     tl.debug(`numberOfPackagesToKeep: ${taskParams.numberOfPackagesToKeep}`);

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -121,7 +121,7 @@
             "name": "commitSubmission",
             "type": "boolean",
             "label": "Commit Submission",
-            "defaultValue": false,
+            "defaultValue": true,
             "groupName": "advanced",
             "required": true,
             "helpMarkDown": "Commit the submission after creating it in Dev Center. Not submitting allows Marketing teams to manually review the submission details before committing."

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -118,6 +118,15 @@
             "helpMarkDown": "Paths to any additional packages required by this application (one path per line). Minimatch pattern is supported."
         },
         {
+            "name": "commitSubmission",
+            "type": "boolean",
+            "label": "Commit Submission",
+            "defaultValue": false,
+            "groupName": "advanced",
+            "required": true,
+            "helpMarkDown": "Commit the submission after creating it in Dev Center. Not submitting allows Marketing teams to manually review the submission details before committing."
+        },
+        {
             "name": "skipPolling",
             "type": "boolean",
             "label": "Skip polling",


### PR DESCRIPTION
See Issue #67 
I added another option under Advanced Options called "commitSubmission"
This defaults to true so the behaviour of the extension will not change for users
If set to false the Submission gets created but not committed
This was useful for us because it allows the marketing team to review the product information manually using the Windows Store UI that they are used to, rather than packing it into the existing git repository, which they would have found alientating. However, it allows our Dev team to automate the process of creating a Windows Store submission and uploading the latest appxupload package to it.