### PR TITLE
Staged Rollout Deployment

### DIFF
--- a/tasks/common/apiHelper.ts
+++ b/tasks/common/apiHelper.ts
@@ -369,9 +369,10 @@ export function commitSubmission(token: request.AccessToken, url: string): Q.Pro
  * Updates submission's package delivery options.
  * @param submissionResource The current submission request
  * @param mandatoryUpdateDifferHours The number of hours to differ until the packages in this submission become mandatory
+ * @param rolloutPercentage The percentage that a staged rollout will happen at
  * @returns A promise for the update of the submission on the server.
  */
-export function updatePackageDeliveryOptions(submissionResource: any, mandatoryUpdateDifferHours?: number): void
+export function updatePackageDeliveryOptions(submissionResource: any, mandatoryUpdateDifferHours?: number, rolloutPercentage?: number): void
 {
     var mandatoryUpdateEffectiveDate: Date = new Date(0);
     if (mandatoryUpdateDifferHours) {
@@ -383,6 +384,13 @@ export function updatePackageDeliveryOptions(submissionResource: any, mandatoryU
 
     submissionResource.packageDeliveryOptions.isMandatoryUpdate = mandatoryUpdateDifferHours !== null;
     submissionResource.packageDeliveryOptions.mandatoryUpdateEffectiveDate = mandatoryUpdateEffectiveDate.toISOString();
+
+    if (rolloutPercentage !== null) {
+        submissionResource.packageDeliveryOptions.packageRollout = {
+            isPackageRollout: true,
+            packageRolloutPercentage: rolloutPercentage.toPrecision()
+        };
+    }
 }
 
 /**

--- a/tasks/store-flight/flight.ts
+++ b/tasks/store-flight/flight.ts
@@ -43,6 +43,9 @@ export interface CoreFlightParams
 
     /** If provided, specified the number of hours to differ until the packages in this submission become mandatory. */
     mandatoryUpdateDifferHours?: number;
+    
+    /** If provided, specifies that the build only be rolled out to a specific percentage of people. */
+    rolloutPercentage?: number;
 }
 
 export interface AppIdParam
@@ -120,7 +123,7 @@ export async function flightTask(params: FlightParams)
     }
 
     console.log('Updating package delivery options...');
-    await api.updatePackageDeliveryOptions( flightSubmissionResource, taskParams.mandatoryUpdateDifferHours);
+    await api.updatePackageDeliveryOptions( flightSubmissionResource, taskParams.mandatoryUpdateDifferHours, taskParams.rolloutPercentage);
 
     console.log('Updating flight submission...');
     await putFlightSubmission(flightSubmissionResource);

--- a/tasks/store-flight/flightUi.ts
+++ b/tasks/store-flight/flightUi.ts
@@ -44,7 +44,8 @@ function gatherParams()
         packages: [],
         skipPolling: tl.getBoolInput('skipPolling', true),
         numberOfPackagesToKeep: tl.getBoolInput('deletePackages') ? parseInt(tl.getInput('numberOfPackagesToKeep')) : null,
-        mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null
+        mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null,
+        rolloutPercentage: tl.getBoolInput('isStagedRollout') ? parseFloat(tl.getInput('rolloutPercentage')) : null
     };
 
     // Packages

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -180,7 +180,8 @@
             "defaultValue": 100.00,
             "groupName": "advanced",
             "required": false,
-            "helpMarkDown": "Indicates what percentage to start the rollout with."
+            "helpMarkDown": "Indicates what percentage to start the rollout with.",
+            "visibleRule": "isStagedRollout = true"
         }
     ],
     "execution": {

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -163,6 +163,24 @@
                 "EditableOptions": "True"
             },
             "visibleRule": "isMandatoryUpdate = true"
+        },
+        {
+            "name": "isStagedRollout",
+            "type": "boolean",
+            "label": "Staged Rollout",
+            "defaultValue": false,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Indicates whether you want to roll out updates gradually after this submission is published."
+        },
+        {
+            "name": "rolloutPercentage",
+            "type": "string",
+            "label": "Rollout Percentage",
+            "defaultValue": 100.00,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Indicates what percentage to start the rollout with."
         }
     ],
     "execution": {

--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -95,6 +95,9 @@ export interface CorePublishParams
 
     /** If provided, specified the number of hours to differ until the packages in this submission become mandatory. */
     mandatoryUpdateDifferHours?: number;
+
+    /** If provided, specifies that the build only be rolled out to a specific percentage of people. */
+    rolloutPercentage?: number;
 }
 
 export interface AppIdParam
@@ -178,7 +181,7 @@ export async function publishTask(params: PublishParams)
     }
 
     console.log('Updating package delivery options...');
-    await api.updatePackageDeliveryOptions(submissionResource, taskParams.mandatoryUpdateDifferHours);
+    await api.updatePackageDeliveryOptions(submissionResource, taskParams.mandatoryUpdateDifferHours, taskParams.rolloutPercentage);
 
     console.log('Updating submission...');
     await putMetadata(submissionResource);

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -45,7 +45,8 @@ function gatherParams()
         packages : [],
         skipPolling : tl.getBoolInput('skipPolling', true),
         numberOfPackagesToKeep: tl.getBoolInput('deletePackages') ? parseInt(tl.getInput('numberOfPackagesToKeep')) : null,
-        mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null
+        mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null,
+        rolloutPercentage: tl.getBoolInput('isStagedRollout') ? parseFloat(tl.getInput('rolloutPercentage')) : null
     };
 
     // Packages

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -201,7 +201,8 @@
             "defaultValue": 100.00,
             "groupName": "advanced",
             "required": false,
-            "helpMarkDown": "Indicates what percentage to start the rollout with."
+            "helpMarkDown": "Indicates what percentage to start the rollout with.",
+            "visibleRule": "isStagedRollout = true"
         }
     ],
     "execution": {

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -184,6 +184,24 @@
                 "EditableOptions": "True"
             },
             "visibleRule": "isMandatoryUpdate = true"
+        },
+        {
+            "name": "isStagedRollout",
+            "type": "boolean",
+            "label": "Staged Rollout",
+            "defaultValue": false,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Indicates whether you want to roll out updates gradually after this submission is published."
+        },
+        {
+            "name": "rolloutPercentage",
+            "type": "string",
+            "label": "Rollout Percentage",
+            "defaultValue": 100.00,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Indicates what percentage to start the rollout with."
         }
     ],
     "execution": {


### PR DESCRIPTION
So I saw there wasn't much movement on https://github.com/microsoft/windows-dev-center-vsts-extension/issues/53 so I whipped something up. This just adds the Staged Rollout parameter to the Store Task. My org uses staged rollouts almost exclusively, so we can't use this task unless it has it.

I wasn't able to get it building per the instructions because I guess my version of node is too high, and I get the "primordials not defined" error? I guess older versions of graceful-fs have this problem with newer versions of node. (as per https://stackoverflow.com/questions/56245622/foundation-referenceerror-primordials-is-not-define-when-starting-a-foundati )

Let me know if there's any problems with this, thanks!
