### PR TITLE
Migrate Tasks to Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "streamifier": "^0.1.1",
     "url": "^0.11.0",
     "uuid": "^3.0.1",
-    "vsts-task-lib": "^0.9.5"
+    "azure-pipelines-task-lib": "^4.1.0"
   },
   "devDependencies": {
+    "typescript": "4.0.2",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-exec": "^2.1.2",
@@ -29,7 +30,7 @@
     "gulp-replace": "^0.5.4",
     "gulp-tsc": "^1.2.0",
     "shelljs": "^0.7.3",
-    "vsts-task-lib": "^0.9.5",
+    "azure-pipelines-task-lib": "^4.1.0",
     "yargs": "^4.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     "url": "https://github.com/Microsoft/windows-dev-center-vsts-extension"
   },
   "dependencies": {
+    "@types/form-data": "^2.5.0",
+    "@types/minimatch": "^5.1.2",
+    "@types/node": "^16.11.39",
+    "@types/node-uuid": "^0.0.29",
+    "@types/q": "1.5.5",
+    "@types/request": "^2.48.8",
     "azure-storage": "^1.3.1",
     "glob": "^7.0.3",
     "jszip": "^3.1.1",

--- a/tasks/common/apiHelper.ts
+++ b/tasks/common/apiHelper.ts
@@ -13,7 +13,7 @@ import path = require('path');
 var JSZip = require('jszip'); // JSZip typings have not been updated to the version we're using
 import Q = require('q');
 import stream = require('stream');
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 var azure = require('azure-storage');
 var url = require('url');
 

--- a/tasks/common/inputHelper.ts
+++ b/tasks/common/inputHelper.ts
@@ -2,7 +2,7 @@
  * General helper to process input variables.
  */
 
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 import path = require('path');
 
 var glob = require('glob');

--- a/tasks/common/requestHelper.ts
+++ b/tasks/common/requestHelper.ts
@@ -10,7 +10,7 @@ import http = require('http'); // Only used for types
 import uuidV4 = require('uuid/v4');
 import Q = require('q');
 import request = require('request');
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 var streamifier = require('streamifier'); // streamifier has no typings
 
 /** How long to wait between retries (in ms) */

--- a/tasks/store-flight/flight.ts
+++ b/tasks/store-flight/flight.ts
@@ -4,13 +4,13 @@
  */
 
 /// <reference path="../../typings/index.d.ts" />
-/// <reference path="../../node_modules/vsts-task-lib/task.d.ts" />
+/// <reference path="../../node_modules/azure-pipelines-task-lib/task.d.ts" />
 
 import api = require('../common/apiHelper');
 import request = require('../common/requestHelper');
 
 import Q = require('q');
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 
 /** Core parameters for the flight task. */
 export interface CoreFlightParams

--- a/tasks/store-flight/flightUi.ts
+++ b/tasks/store-flight/flightUi.ts
@@ -9,7 +9,7 @@ import fli = require('./flight');
 
 import path = require('path');
 
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 
 /** Obtain and validate parameters from task UI. */
 function gatherParams()

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -17,7 +17,7 @@
         "Minor": "2",
         "Patch": "28"
     },
-    "minimumAgentVersion": "1.83.0",
+    "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Flight $(packagePath) to $(flightName)",
     "groups": [
         {
@@ -167,6 +167,14 @@
     ],
     "execution": {
         "Node": {
+            "target": "local/flightUi.js",
+            "argumentFormat": ""
+        },
+        "Node10": {
+            "target": "local/flightUi.js",
+            "argumentFormat": ""
+        },
+        "Node16": {
             "target": "local/flightUi.js",
             "argumentFormat": ""
         }

--- a/tasks/store-publish/publish.ts
+++ b/tasks/store-publish/publish.ts
@@ -4,7 +4,7 @@
  */
 
 /// <reference path="../../typings/index.d.ts" />
-/// <reference path="../../node_modules/vsts-task-lib/task.d.ts" />
+/// <reference path="../../node_modules/azure-pipelines-task-lib/task.d.ts" />
 
 import api = require('../common/apiHelper');
 import request = require('../common/requestHelper');
@@ -13,7 +13,7 @@ import fs = require('fs');
 import path = require('path');
 
 import Q = require('q');
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 
 /** Expected imageType values */
 const imageType: string[] = [

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -9,7 +9,7 @@ import pub = require('./publish');
 
 import path = require('path');
 
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 
 /** Obtain and validate parameters from task UI. */
 function gatherParams()

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -17,7 +17,7 @@
         "Minor": "10",
         "Patch": "30"
     },
-    "minimumAgentVersion": "1.83.0",
+    "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Publish $(packagePath)",
     "groups": [
         {
@@ -188,6 +188,14 @@
     ],
     "execution": {
         "Node": {
+            "target": "local/publishUi.js",
+            "argumentFormat": ""
+        },
+        "Node10": {
+            "target": "local/publishUi.js",
+            "argumentFormat": ""
+        },
+        "Node16": {
             "target": "local/publishUi.js",
             "argumentFormat": ""
         }


### PR DESCRIPTION
Reviewers and contributors, please follow the migration to node16 guide we have for in-the-box ADO tasks:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode16.md

This PR is not ready to be merged, it is just a starting point to help contributors start.

The Node 16 migration guide is created keeping in mind that the in-the-box ADO tasks were already migrated to Node 10. In order to ensure smooth migration to Node 16, we need to ensure that the task can be run using a Node 10 handler as well. Please refer to the following guide for the same:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode10.md

Since vsts-task-lib is deprecated, it should be replaced by azure-pipelines-task-lib. Also since typings is deprecated, I believe the typings.json file should be removed and @types packages should be used. It can be done by adding @types packages to package.json dependencies.

Please be sure to retest all tasks on node 10 and16 thoroughly