### PR TITLE
hot fix store publish task

### DIFF
--- a/tasks/common/apiHelper.ts
+++ b/tasks/common/apiHelper.ts
@@ -454,7 +454,7 @@ function uploadZip(filePath: string, blobUrl: string): Q.Promise<any>
 
     blockBlobClient.uploadFile(filePath, options)
         .then(() => {
-            console.log(`Successfully uploaded file!`);
+            tl.debug(`Successfully uploaded file!`);
             defer.resolve();
         })
         .catch(err => {

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "0",
         "Minor": "2",
-        "Patch": "29"
+        "Patch": "30"
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Flight $(packagePath) to $(flightName)",

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": "0",
         "Minor": "10",
-        "Patch": "31"
+        "Patch": "32"
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Publish $(packagePath)",
@@ -192,11 +192,11 @@
             "argumentFormat": ""
         },
         "Node10": {
-            "target": "local/flightUi.js",
+            "target": "local/publishUi.js",
             "argumentFormat": ""
         },
         "Node16": {
-            "target": "local/flightUi.js",
+            "target": "local/publishUi.js",
             "argumentFormat": ""
         }
     }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿{
     "manifestVersion": 1,
     "id": "windows-store-publish",
-    "version": "0.9.35",
+    "version": "0.9.36",
     "name": "Windows Store",
     "publisher": "ms-rdx-mro",
     "description": "Publish your applications on the Windows Store.",


### PR DESCRIPTION
This pull request includes updates to various files in the codebase. The most important changes include updating the `target` property and `Patch` value in `tasks/store-publish/task.json`, updating the logging statement in `tasks/common/apiHelper.ts`, and updating the version property in `vss-extension.json`.

Main updates:

* [`tasks/store-publish/task.json`](diffhunk://#diff-32eb5937231f80eb4f68dfeb69657ed6b9869ce485b4be2f614af8772718f0e8L195-R199): Updated the `target` property in the `Node10` and `Node16` sections to point to `local/publishUi.js`, and updated the `Patch` property in the `version` section from "31" to "32". [[1]](diffhunk://#diff-32eb5937231f80eb4f68dfeb69657ed6b9869ce485b4be2f614af8772718f0e8L195-R199) [[2]](diffhunk://#diff-32eb5937231f80eb4f68dfeb69657ed6b9869ce485b4be2f614af8772718f0e8L18-R18)
* [`tasks/common/apiHelper.ts`](diffhunk://#diff-d633302c1504b696436e5eb8702e0ea72157dde7311de23cacd2bc841f7a8955L457-R457): Updated the `console.log` statement in the `uploadZip` function to `tl.debug` for improved logging.
* [`vss-extension.json`](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L4-R4): Updated the version property from "0.9.35" to "0.9.36".

Additional update:

* [`tasks/store-flight/task.json`](diffhunk://#diff-81fe7c61e622a4192232ed30a7a9b4c1015331438efc251dfcb4ca8f0ddc5eeaL18-R18): Updated the `Patch` value from "29" to "30".