### PR TITLE
Add commitSubmission param to both tasks (enabled by default)

### DIFF
--- a/tasks/store-flight/flightUi.ts
+++ b/tasks/store-flight/flightUi.ts
@@ -42,6 +42,7 @@ function gatherParams()
         force: tl.getBoolInput('force', true),
         zipFilePath: path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
         packages: [],
+        commitSubmission: tl.getBoolInput('commitSubmission', true),
         skipPolling: tl.getBoolInput('skipPolling', true),
         numberOfPackagesToKeep: tl.getBoolInput('deletePackages') ? parseInt(tl.getInput('numberOfPackagesToKeep')) : null,
         mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null
@@ -101,6 +102,7 @@ function dumpParams(taskParams: fli.FlightParams): void
     tl.debug(`Force delete: ${taskParams.force}`);
     tl.debug(`Packages: ${taskParams.packages.join(',')}`);
     tl.debug(`Local ZIP file path: ${taskParams.zipFilePath}`);
+    tl.debug(`commitSubmission: ${taskParams.commitSubmission}`);
     tl.debug(`skipPolling: ${taskParams.skipPolling}`);
     tl.debug(`deletePackages: ${taskParams.numberOfPackagesToKeep ? true : false}`);
     tl.debug(`numberOfPackagesToKeep: ${taskParams.numberOfPackagesToKeep}`);

--- a/tasks/store-flight/task.json
+++ b/tasks/store-flight/task.json
@@ -14,8 +14,8 @@
     ],
     "version": {
         "Major": "0",
-        "Minor": "2",
-        "Patch": "30"
+        "Minor": "3",
+        "Patch": "0"
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Flight $(packagePath) to $(flightName)",
@@ -97,15 +97,6 @@
             "helpMarkDown": "Paths to any additional packages required by this application (one path per line). Minimatch pattern is supported."
         },
         {
-            "name": "skipPolling",
-            "type": "boolean",
-            "label": "Skip polling",
-            "defaultValue": false,
-            "groupName": "advanced",
-            "required": true,
-            "helpMarkDown": "Skip polling submission after committing it to Dev Center. **Warning**: if you check this box, you will not see errors, if any, that your submission may run into. You will have to manually check the status of your submission in Dev Center."
-        },
-        {
             "name": "deletePackages",
             "type": "boolean",
             "label": "Delete Packages",
@@ -163,6 +154,25 @@
                 "EditableOptions": "True"
             },
             "visibleRule": "isMandatoryUpdate = true"
+        },
+        {
+            "name": "commitSubmission",
+            "type": "boolean",
+            "label": "Commit Submission",
+            "defaultValue": true,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Commit a submission to Dev Center."
+        },
+        {
+            "name": "skipPolling",
+            "type": "boolean",
+            "label": "Skip polling",
+            "defaultValue": false,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Skip polling submission after committing it to Dev Center. **Warning**: if you check this box, you will not see errors, if any, that your submission may run into. You will have to manually check the status of your submission in Dev Center.",
+            "visibleRule": "commitSubmission = true"
         }
     ],
     "execution": {

--- a/tasks/store-publish/publishUi.ts
+++ b/tasks/store-publish/publishUi.ts
@@ -43,6 +43,7 @@ function gatherParams()
         updateImages: tl.getBoolInput('updateImages', false),
         zipFilePath : path.join(tl.getVariable('Agent.WorkFolder'), 'temp.zip'),
         packages : [],
+        commitSubmission : tl.getBoolInput('commitSubmission', true),
         skipPolling : tl.getBoolInput('skipPolling', true),
         numberOfPackagesToKeep: tl.getBoolInput('deletePackages') ? parseInt(tl.getInput('numberOfPackagesToKeep')) : null,
         mandatoryUpdateDifferHours: tl.getBoolInput('isMandatoryUpdate') ? parseInt(tl.getInput('mandatoryUpdateDifferHours')) : null
@@ -101,6 +102,7 @@ function dumpParams(taskParams: pub.PublishParams): void
     tl.debug(`Update images: ${taskParams.updateImages}`);
     tl.debug(`Metadata root: ${taskParams.metadataRoot}`);
     tl.debug(`Packages: ${taskParams.packages.join(',')}`);
+    tl.debug(`commitSubmission: ${taskParams.commitSubmission}`);
     tl.debug(`skipPolling: ${taskParams.skipPolling}`);
     tl.debug(`deletePackages: ${taskParams.numberOfPackagesToKeep ? true : false}`);
     tl.debug(`numberOfPackagesToKeep: ${taskParams.numberOfPackagesToKeep}`);

--- a/tasks/store-publish/task.json
+++ b/tasks/store-publish/task.json
@@ -14,8 +14,8 @@
     ],
     "version": {
         "Major": "0",
-        "Minor": "10",
-        "Patch": "32"
+        "Minor": "11",
+        "Patch": "0"
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Publish $(packagePath)",
@@ -118,15 +118,6 @@
             "helpMarkDown": "Paths to any additional packages required by this application (one path per line). Minimatch pattern is supported."
         },
         {
-            "name": "skipPolling",
-            "type": "boolean",
-            "label": "Skip polling",
-            "defaultValue": false,
-            "groupName": "advanced",
-            "required": true,
-            "helpMarkDown": "Skip polling submission after committing it to Dev Center. **Warning**: if you check this box, you will not see errors, if any, that your submission may run into. You will have to manually check status of your submission in Dev Center."
-        },
-        {
             "name": "deletePackages",
             "type": "boolean",
             "label": "Delete Packages",
@@ -184,6 +175,25 @@
                 "EditableOptions": "True"
             },
             "visibleRule": "isMandatoryUpdate = true"
+        },
+        {
+            "name": "commitSubmission",
+            "type": "boolean",
+            "label": "Commit Submission",
+            "defaultValue": true,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Commit a submission to Dev Center."
+        },
+        {
+            "name": "skipPolling",
+            "type": "boolean",
+            "label": "Skip polling",
+            "defaultValue": false,
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Skip polling submission after committing it to Dev Center. **Warning**: if you check this box, you will not see errors, if any, that your submission may run into. You will have to manually check status of your submission in Dev Center.",
+            "visibleRule": "commitSubmission = true"
         }
     ],
     "execution": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿{
     "manifestVersion": 1,
     "id": "windows-store-publish",
-    "version": "0.9.36",
+    "version": "0.10.0",
     "name": "Windows Store",
     "publisher": "ms-rdx-mro",
     "description": "Publish your applications on the Windows Store.",


### PR DESCRIPTION
This PR adds new parameter which allows to disable automatic commit of updated submission.

__New param__:  _commitSubmission_ - defaults to true to preserver the current behavior

__Motivation__: I want to have an automation build which prepares new submission and upload new binaries but still allows to manually update and review metadata before sending the submission to certification.