### PR TITLE
Users/tianw/postv3migration

### DIFF
--- a/Pipelines/templates/OfficePipelineTemplateSettings.yml
+++ b/Pipelines/templates/OfficePipelineTemplateSettings.yml
@@ -9,8 +9,8 @@ resources:
   repositories:
   - repository: OfficePipelineTemplates
     type: git
-    name: OE/OfficePipelineTemplates
-    ref: refs/heads/main
+    name: 1ESPipelineTemplates/OfficePipelineTemplates
+    ref: refs/tags/release
 
 extends:
   ${{ if parameters.isProduction }}:

--- a/tasks/store-publish-V3/publish.psm1
+++ b/tasks/store-publish-V3/publish.psm1
@@ -266,7 +266,7 @@ function Start-Publishing
         else
         {
             Write-Verbose "Source Folder of packages: $SourceFolder"
-            $submissionJson = @{
+            $submissionJson = [PSCustomObject]@{
                 'ProductId' = $productId
                 'ApplicationPackages' = (Get-SubmissionPackages -SourceFolder $SourceFolder -Contents $Contents)
             }
@@ -274,7 +274,7 @@ function Start-Publishing
             Write-Verbose "Metadata update type: $MetadataUpdateMethod"
             if ($ReleaseTrack -eq 'Flight' -or $MetadataUpdateMethod -eq 'NoUpdate')
             {
-                $submissionJson.listings = @{}
+                $submissionJson.listings = [PSCustomObject]@{}
                 $submissionParameters['JsonObject'] = [PSCustomObject]$submissionJson
                 $submissionParameters['PackageRootPath'] = $SourceFolder
                 $submissionParameters['MediaRootPath'] = $SourceFolder
@@ -521,7 +521,7 @@ function Update-MetadataListings
 
     Write-Verbose "Metadata Folder path: $MetadataSource"
     Write-Verbose "Update images and captions: $UpdateImagesAndCaptions"
-    $listingsMap = @{}
+    $listingsMap = [PSCustomObject]@{}
     $listingSource = [IO.Path]::Combine($MetadataSource, "Listings")
 
     Write-Verbose "Getting listings from $listingSource"
@@ -546,7 +546,7 @@ function Update-MetadataListings
             Update-ImageListings -ListingAbsPath $listingAbsPath -ListingAttributes $listingAttributes -MetadataSource $MetadataSource
         }
         $listingAttributes.baseListing = [PSCustomObject] $listingAttributes.baseListing
-        $listingsMap[$listing.Name] = $listingAttributes
+        $listingsMap | Add-Member -Name $listing.Name -Type NoteProperty -Value $listingAttributes
     }
 
     return $listingsMap

--- a/tasks/store-publish-V3/publish.psm1
+++ b/tasks/store-publish-V3/publish.psm1
@@ -266,7 +266,7 @@ function Start-Publishing
         else
         {
             Write-Verbose "Source Folder of packages: $SourceFolder"
-            $submissionJson = [PSCustomObject]@{
+            $submissionJson = @{
                 'ProductId' = $productId
                 'ApplicationPackages' = (Get-SubmissionPackages -SourceFolder $SourceFolder -Contents $Contents)
             }
@@ -275,7 +275,7 @@ function Start-Publishing
             if ($ReleaseTrack -eq 'Flight' -or $MetadataUpdateMethod -eq 'NoUpdate')
             {
                 $submissionJson.listings = [PSCustomObject]@{}
-                $submissionParameters['JsonObject'] = [PSCustomObject]$submissionJson
+                $submissionParameters['JsonObject'] = $submissionJson
                 $submissionParameters['PackageRootPath'] = $SourceFolder
                 $submissionParameters['MediaRootPath'] = $SourceFolder
             }

--- a/tasks/store-publish-V3/task.json
+++ b/tasks/store-publish-V3/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": "3",
         "Minor": "0",
-        "Patch": "24"
+        "Patch": "25"
     },
     "minimumAgentVersion": "2.117.0",
     "instanceNameFormat": "Publish $(appName)",

--- a/tasks/store-publish-V3/task.json
+++ b/tasks/store-publish-V3/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": "3",
         "Minor": "0",
-        "Patch": "23"
+        "Patch": "24"
     },
     "minimumAgentVersion": "2.117.0",
     "instanceNameFormat": "Publish $(appName)",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿{
     "manifestVersion": 1,
     "id": "windows-store-publish",
-    "version": "2.4.32",
+    "version": "2.4.33",
     "name": "Windows Store",
     "publisher": "ms-rdx-mro",
     "description": "Publish your applications on the Windows Store.",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 ﻿{
     "manifestVersion": 1,
     "id": "windows-store-publish",
-    "version": "2.4.31",
+    "version": "2.4.32",
     "name": "Windows Store",
     "publisher": "ms-rdx-mro",
     "description": "Publish your applications on the Windows Store.",


### PR DESCRIPTION
This pull request includes several changes to the `tasks/store-publish-V3` module to improve the handling of PowerShell objects and update versioning information. The most important changes include converting hashtables to `PSCustomObject` for better structure and updating version numbers in relevant JSON files.

Improvements to PowerShell object handling:

* [`tasks/store-publish-V3/publish.psm1`](diffhunk://#diff-2817dfffce3e966df391a8919ffd97f1d6f51b9a8ffce2ccf44c42f9df535c11L269-R277): Converted hashtables to `PSCustomObject` in `Start-Publishing` function to ensure proper object structure.
* [`tasks/store-publish-V3/publish.psm1`](diffhunk://#diff-2817dfffce3e966df391a8919ffd97f1d6f51b9a8ffce2ccf44c42f9df535c11L524-R524): Updated `Update-MetadataListings` function to use `PSCustomObject` and `Add-Member` for better handling of listings. [[1]](diffhunk://#diff-2817dfffce3e966df391a8919ffd97f1d6f51b9a8ffce2ccf44c42f9df535c11L524-R524) [[2]](diffhunk://#diff-2817dfffce3e966df391a8919ffd97f1d6f51b9a8ffce2ccf44c42f9df535c11L549-R549)

Version updates:

* [`tasks/store-publish-V3/task.json`](diffhunk://#diff-6ec7e8b7b07fe3642b5ee7b54c22974d7999a125faa62247b9c404c85d31582eL19-R19): Incremented the patch version from `3.0.23` to `3.0.24`.
* [`vss-extension.json`](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L4-R4): Incremented the version from `2.4.31` to `2.4.32`.